### PR TITLE
Export findLicense

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "license",
   "version": "1.0.2",
-  "main": "dist/getLicense.js",
+  "main": "dist/index.js",
   "author": "Ovyerus <iamovyerus@gmail.com>",
   "license": "MIT",
   "description": "Easily generate licenses for your projects!",
@@ -9,7 +9,7 @@
     "license": "dist/cli/index.js"
   },
   "files": [
-  	"dist"
+    "dist"
   ],
   "scripts": {
     "test": "jest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { default, getLicense } from "./getLicense";
-export * from "./findLicense";
+export { findLicense } from "./findLicense";


### PR DESCRIPTION
## The problem
As the export is defined today, `findLicense` can't be imported.

## The solution
By defining `main` as `index.js`, you control better which functions are exported and can be imported from the final bundle.