### PR TITLE
feat(cli): options via `LICENSE_*` env vars

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -37,6 +37,7 @@ export default function main() {
     .scriptName(pkg.name)
     .version(pkg.version)
     .usage("Usage: license [--help] [--version] [command]")
+    .env("LICENSE")
     .command(
       "$0 [license]",
       "Generate a license file.",


### PR DESCRIPTION
Allows users to specify options as `LICENSE_*` environment variables, leveraging the built-in [`.env(prefix)` from `yargs`][yargs-env].

```sh
$ LICENSE_NAME="John Doe" LICENSE_EMAIL="john.doe@example.com" license MIT
```

Explicitly specified CLI options take precedence over environment variables.

```sh
$ LICENSE_NAME="John Doe" LICENSE_EMAIL="john.doe@example.com" license --email "johnny@example.com" MIT
```

This is very useful, when combined with tools like [`direnv`][direnv] to manage defaults per directory.

[yargs-env]: https://github.com/yargs/yargs/blob/master/docs/api.md#envprefix
[direnv]: https://github.com/direnv/direnv