### PR TITLE
fix: year replacement templating in the Apache 2.0 license

### DIFF
--- a/src/getLicense.spec.ts
+++ b/src/getLicense.spec.ts
@@ -1,4 +1,5 @@
 import MIT from "@ovyerus/licenses/licenses/MIT.json";
+import Apache20 from "@ovyerus/licenses/licenses/Apache-2.0.json";
 
 import getLicense from "./getLicense";
 
@@ -9,6 +10,14 @@ test("gets the MIT license template", () => {
 test("replaces the author and year fields in the MIT license", () => {
   expect(getLicense("MIT", { author: "Ovyerus", year: "2020" })).toEqual(
     MIT.licenseText.replace(/<author>/g, "Ovyerus").replace(/<year>/g, "2020")
+  );
+});
+
+test("replaces the author and year fields in the Apache-2.0 license", () => {
+  expect(getLicense("Apache-2.0", { author: "Ovyerus", yyyy: "2020" })).toEqual(
+    Apache20.licenseText
+      .replace(/<author>/g, "Ovyerus")
+      .replace(/\[(yyyy)\]/g, "2020")
   );
 });
 

--- a/src/getLicense.ts
+++ b/src/getLicense.ts
@@ -26,7 +26,10 @@ export function getLicense(
     // Remove any undefined or falsey values
     ([, value]) => value
   ))
-    modified = modified.replace(new RegExp(`<${key}>`, "g"), value);
+    modified = modified
+      .replace(new RegExp(`<${key}>`, "g"), value)
+      // Some licenses, like Apache 2.0 use square bracket templating for some values.
+      .replace(new RegExp(`\\[${key}\\]`, "g"), value);
 
   return modified;
 }


### PR DESCRIPTION
This updates the `getLicense()` method to support `[key]` style templating, like Apache 2.0 uses for `[yyyy]`, resolving https://github.com/Ovyerus/license/issues/12.